### PR TITLE
Fix: Correct script entry point in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 ]
 
 [project.scripts]
-daylight = "daylight_py:main"
+daylight = "daylight_py.main:main"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
The previous entry point `daylight_py:main` was causing a TypeError because it attempted to call the `daylight_py.main` module as a function.

This commit changes the entry point to `daylight_py.main:main`, which correctly targets the `main()` function within the `daylight_py.main` module, resolving the TypeError.